### PR TITLE
aiohttpparser: Fix 500 error with JSON content-type and empty body

### DIFF
--- a/webargs/aiohttpparser.py
+++ b/webargs/aiohttpparser.py
@@ -97,7 +97,14 @@ class AIOHTTPParser(AsyncParser):
         if json_data is None:
             if not (req.body_exists and is_json_request(req)):
                 return core.missing
-            self._cache["json"] = json_data = await req.json()
+            try:
+                json_data = await req.json()
+            except json.JSONDecodeError as e:
+                if e.doc == '':
+                    return core.missing
+                else:
+                    raise e
+            self._cache["json"] = json_data
         return core.get_value(json_data, name, field, allow_many_nested=True)
 
     def parse_headers(self, req, name, field):


### PR DESCRIPTION
Fixes 500 errors when Content-Type is JSON and the request body is empty.
This is done by catching the resulting JSONDecodeError and checking whether the input is empty.